### PR TITLE
[RTD-602] Return unauthorized if internal ID is missing

### DIFF
--- a/postman/sender_auth_component_test.postman_collection.json
+++ b/postman/sender_auth_component_test.postman_collection.json
@@ -183,7 +183,7 @@
 					"script": {
 						"exec": [
 							"pm.test('002b - Fail GET sender code: missing param value', () => {",
-							"    pm.response.to.have.status(404);",
+							"    pm.response.to.have.status(401);",
 							"    pm.response.to.have.body(\"\");",
 							"});"
 						],
@@ -217,7 +217,7 @@
 					"script": {
 						"exec": [
 							"pm.test('002c - Fail GET sender code: api key not found', () => {",
-							"    pm.response.to.have.status(404);",
+							"    pm.response.to.have.status(401);",
 							"});"
 						],
 						"type": "text/javascript"

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmssenderauth/controller/RestExceptionHandler.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmssenderauth/controller/RestExceptionHandler.java
@@ -13,7 +13,7 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
 
   @ExceptionHandler(RecordNotFoundException.class)
   protected ResponseEntity<String> handleEntityNotFound(RecordNotFoundException ex) {
-    return ResponseEntity.notFound().build();
+    return ResponseEntity.status(401).build();
   }
 
   @ExceptionHandler(SenderCodeAssociatedToAnotherApiKey.class)

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmssenderauth/controller/RestControllerTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmssenderauth/controller/RestControllerTest.java
@@ -59,7 +59,7 @@ class RestControllerTest {
     mockMvc.perform(MockMvcRequestBuilders
             .get(BASE_URI + GETSENDERCODE_ENDPOINT)
             .param("internalId", "xxx"))
-        .andExpectAll(status().isNotFound());
+        .andExpectAll(status().isUnauthorized());
   }
 
   @SneakyThrows


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to change status code returned from 404 to 401 in case of missing internal ID.

#### List of Changes
<!--- Describe your changes in detail -->
- change status code in response entity
- adapt test

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this change we hide the presence or absence of an internal ID by returning 401 even in internal ID is not present in first instance.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Unit Test Suite
- [x] Integration Test Suite
- [x] Api Tests
- [ ] Load Tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.