### PR TITLE
breaking: RTD-2629 tae migration to workloadIdentity

### DIFF
--- a/.devops/cstar-rtd-deploy-pipelines.yml
+++ b/.devops/cstar-rtd-deploy-pipelines.yml
@@ -7,7 +7,7 @@ parameters:
     type: boolean
     default: true
   - name: 'buildNative'
-    displayName: 'Deploy and build native version'
+    displayName: 'Build with native version'
     type: boolean
     default: true
 

--- a/.devops/cstar-rtd-deploy-pipelines.yml
+++ b/.devops/cstar-rtd-deploy-pipelines.yml
@@ -49,6 +49,7 @@ variables:
     kubernetesServiceConnection: '$(DEV_KUBERNETES_SERVICE_CONN)'
     containerRegistry: '$(DEV_CONTAINER_REGISTRY_NAME)'
     selfHostedAgentPool: $(DEV_AGENT_POOL)
+    workloadIdentityClientId: '$(DEV_RTD_WORKLOAD_IDENTITY_CLIENT_ID)'
 
   ${{ elseif startsWith(variables['Build.SourceBranch'], 'refs/heads/uat') }}:
     environment: 'UAT'
@@ -58,6 +59,7 @@ variables:
     kubernetesServiceConnection: '$(UAT_KUBERNETES_SERVICE_CONN)'
     containerRegistry: '$(UAT_CONTAINER_REGISTRY_NAME)'
     selfHostedAgentPool: $(UAT_AGENT_POOL)
+    workloadIdentityClientId: '$(UAT_RTD_WORKLOAD_IDENTITY_CLIENT_ID)'
 
   ${{ elseif startsWith(variables['Build.SourceBranch'], 'refs/heads/main') }}:
     environment: 'PROD'
@@ -67,6 +69,7 @@ variables:
     kubernetesServiceConnection: '$(PROD_KUBERNETES_SERVICE_CONN)'
     containerRegistry: '$(PROD_CONTAINER_REGISTRY_NAME)'
     selfHostedAgentPool: $(PROD_AGENT_POOL)
+    workloadIdentityClientId: '$(PROD_RTD_WORKLOAD_IDENTITY_CLIENT_ID)'
 
   ${{ else }}:
     environment: 'DEV'
@@ -76,6 +79,7 @@ variables:
     kubernetesServiceConnection: '$(DEV_KUBERNETES_SERVICE_CONN)'
     containerRegistry: '$(DEV_CONTAINER_REGISTRY_NAME)'
     selfHostedAgentPool: $(DEV_AGENT_POOL)
+    workloadIdentityClientId: '$(DEV_RTD_WORKLOAD_IDENTITY_CLIENT_ID)'
 
 stages:
   - stage: 'pom_version'
@@ -195,7 +199,7 @@ stages:
                     valueFile: "$(Pipeline.Workspace)/helm/rtd/values-${{ lower(variables.environment) }}.yaml"
                     install: true
                     waitForExecution: true
-                    arguments: "--timeout 5m00s --debug"
+                    arguments: "--timeout 5m00s --set microservice-chart.azure.workloadIdentityClientId=$(workloadIdentityClientId) --debug"
 
   - stage: 'Component_Test'
     displayName: 'Component test on ${{ variables.environment }}'

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+**/charts/**
+
 # Compiled class file
 *.class
 

--- a/helm/rtd/Chart.lock
+++ b/helm/rtd/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: microservice-chart
+  repository: https://pagopa.github.io/aks-microservice-chart-blueprint
+  version: 8.0.0
+digest: sha256:a62fbaa721b6ba3f059ea5be9d49fa1c9738aa52c53c66b486f91673d7435e86
+generated: "2025-05-19T12:20:12.895015+02:00"

--- a/helm/rtd/Chart.yaml
+++ b/helm/rtd/Chart.yaml
@@ -6,5 +6,5 @@ version: 1.0.0
 appVersion: 1.0.0
 dependencies:
   - name: microservice-chart
-    version: 2.8.0
+    version: 8.0.0
     repository: "https://pagopa.github.io/aks-microservice-chart-blueprint"

--- a/helm/rtd/deploy.sh
+++ b/helm/rtd/deploy.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+# Usage:
+#   ./deploy.sh <values yaml file> <app name or release name>
+#
+# Example:
+#   ./deploy.sh values.yaml my-app-release
+#
+# This script will:
+#   - Read the namespace and keyvault name from the provided values file
+#   - Retrieve the workload identity client ID from Azure Key Vault
+#   - Show the current Kubernetes context
+#   - Render the Helm template for review
+#   - Ask for confirmation before running the Helm upgrade/install
+#   - Deploy the Helm chart to the current cluster context
+
+set -e  # Exit the script if any command fails
+
+# Function to handle errors
+handle_error() {
+    echo "❌ Error: $1" >&2
+    exit 1
+}
+
+# Remove CLUSTER_NAME parameter and logic
+# ENV parameter instead of VALUES_FILE_NAME
+ENV=$1
+APP_NAME=$2
+SECRET_NAME="rtd-workload-identity-client-id"
+
+if [ -z "$ENV" ] || [ -z "$APP_NAME" ]; then
+    handle_error "All parameters are required: ENV APP_NAME"
+fi
+
+# Determine values file paths
+VALUES_FILE_ENV="values-$ENV.yaml"
+VALUES_FILE_GLOBAL="values.yaml"
+
+if [ ! -f "$VALUES_FILE_ENV" ]; then
+    handle_error "File $VALUES_FILE_ENV not found."
+fi
+if [ ! -f "$VALUES_FILE_GLOBAL" ]; then
+    handle_error "File $VALUES_FILE_GLOBAL not found."
+fi
+
+# Use ENV-specific values file for extracting namespace/keyvault
+NAMESPACE=$(yq eval '.microservice-chart.namespace' "$VALUES_FILE_GLOBAL")
+
+if [ -z "$NAMESPACE" ]; then
+    echo "Errore: Impossible to read the namespace"
+    exit 1
+fi
+
+KEYVAULT_NAME=$(yq eval '.microservice-chart.keyvault.name' "$VALUES_FILE_ENV")
+
+if [ -z "$KEYVAULT_NAME" ]; then
+    echo "Errore: Impossibile leggere il nome del Key Vault dal file YAML"
+    exit 1
+fi
+
+CLIENT_ID=$(az keyvault secret show --name "$SECRET_NAME" --vault-name "$KEYVAULT_NAME" --query "value" -o tsv)
+
+# Verifica che il segreto sia stato recuperato correttamente
+if [ -z "$CLIENT_ID" ]; then
+    echo "Errore: Impossible to read the secret value"
+    exit 1
+fi
+
+#
+# K8s
+#
+if ! command -v kubectl &> /dev/null; then
+    handle_error "kubectl is not installed. Please install it and try again."
+fi
+
+if ! command -v helm &> /dev/null; then
+    handle_error "Helm is not installed. Please install it and try again."
+fi
+
+CURRENT_CONTEXT=$(kubectl config current-context)
+echo "ℹ️ Current Kubernetes context: $CURRENT_CONTEXT"
+
+#
+# ⎈ HELM
+#
+echo "🪚 Deleting charts folder"
+rm -rf charts || handle_error "Unable to delete charts folder"
+
+echo "🔨 Starting Helm Template"
+helm dep build && \
+helm template . -f "$VALUES_FILE_ENV" -f "$VALUES_FILE_GLOBAL" \
+  --set microservice-chart.azure.workloadIdentityClientId="$CLIENT_ID" \
+  --debug
+
+echo "Do you want to proceed with the Helm upgrade? (yes/no)"
+read -r user_input
+if [[ "$user_input" != "yes" ]]; then
+  echo "Helm upgrade aborted by user."
+  exit 0
+fi
+
+echo "🚀 Launch helm deploy"
+# Execute helm upgrade/install command and capture output and exit code
+helm upgrade --namespace "$NAMESPACE" \
+    --install \
+    --set microservice-chart.azure.workloadIdentityClientId="$CLIENT_ID" \
+    --values "$VALUES_FILE_ENV" --values "$VALUES_FILE_GLOBAL" \
+    --wait --debug --timeout 15m0s "$APP_NAME" .
+
+exit_code=$?
+
+# Check the command result
+if [ $exit_code -ne 0 ]; then
+    handle_error "Failed to upgrade/install Helm chart"
+else
+    echo "✅ Release installation completed successfully"
+fi

--- a/helm/rtd/deploy.sh
+++ b/helm/rtd/deploy.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # Usage:
-#   ./deploy.sh <values yaml file> <app name or release name>
+#   ./deploy.sh <env> <app name or release name>
 #
 # Example:
-#   ./deploy.sh values.yaml my-app-release
+#   ./deploy.sh dev my-app-release
 #
 # This script will:
 #   - Read the namespace and keyvault name from the provided values file

--- a/helm/rtd/values-dev.yaml
+++ b/helm/rtd/values-dev.yaml
@@ -21,6 +21,10 @@ microservice-chart:
   envSecret:
     aks-api-url: cstar-d-weu-dev01-aks-apiserver-url
 
+  topologySpreadConstraints:
+    create: true
+    useDefaultConfiguration: true
+
 #  autoscaling:
 #    enable: false
 #    minReplica: 1

--- a/helm/rtd/values-dev.yaml
+++ b/helm/rtd/values-dev.yaml
@@ -25,25 +25,24 @@ microservice-chart:
     create: true
     useDefaultConfiguration: true
 
-#  autoscaling:
-#    enable: false
-#    minReplica: 1
-#    maxReplica: 2
-#    pollingInterval: 30 # seconds
-#    cooldownPeriod: 300 # seconds
-#    triggers:
-#      - type: azure-monitor
-#        metadata:
-#          tenantId: 7788edaf-0346-4068-9d79-c868aed15b3d
-#          subscriptionId: ac17914c-79bf-48fa-831e-1359ef74c1d5
-#          resourceGroupName: dvopla-d-sec-rg
-#          resourceURI: Microsoft.KeyVault/vaults/dvopla-d-neu-kv
-#          metricName: ServiceApiHit
-#          # metricNamespace: Microsoft.KeyVault/vaults
-#          # metricFilter: namespace eq 'default'
-#          # metricAggregationInterval: "-1:1:0"
-#          metricAggregationType: Count
-#          targetValue: "30"
+  autoscaling:
+    enable: true
+    minReplica: 0
+    maxReplica: 1
+    pollingInterval: 30 # seconds
+    cooldownPeriod: 10 # seconds
+    triggers:
+      - type: cron
+        metadata:
+          # Required
+          timezone: Europe/Rome  # The acceptable values would be a value from the IANA Time Zone Database.
+          start: 0 7 * * *
+          end: 0 21 * * *
+          desiredReplicas: "1"
+      - type: cpu
+        metadata:
+          type: Utilization
+          value: "60"
 
   keyvault:
     name: "cstar-d-rtd-kv"

--- a/helm/rtd/values-prod.yaml
+++ b/helm/rtd/values-prod.yaml
@@ -16,7 +16,7 @@ microservice-chart:
       cpu: "150m"
 
   deployment:
-    replicas: 2
+    create: true
 
   affinity:
     nodeAffinity:
@@ -35,25 +35,17 @@ microservice-chart:
   envSecret:
     aks-api-url: cstar-p-weu-prod01-aks-apiserver-url
 
-  #  autoscaling:
-  #    enable: false
-  #    minReplica: 1
-  #    maxReplica: 2
-  #    pollingInterval: 30 # seconds
-  #    cooldownPeriod: 300 # seconds
-  #    triggers:
-  #      - type: azure-monitor
-  #        metadata:
-  #          tenantId: 7788edaf-0346-4068-9d79-c868aed15b3d
-  #          subscriptionId: ac17914c-79bf-48fa-831e-1359ef74c1d5
-  #          resourceGroupName: dvopla-d-sec-rg
-  #          resourceURI: Microsoft.KeyVault/vaults/dvopla-d-neu-kv
-  #          metricName: ServiceApiHit
-  #          # metricNamespace: Microsoft.KeyVault/vaults
-  #          # metricFilter: namespace eq 'default'
-  #          # metricAggregationInterval: "-1:1:0"
-  #          metricAggregationType: Count
-  #          targetValue: "30"
+  autoscaling:
+    enable: true
+    minReplica: 2
+    maxReplica: 3
+    pollingInterval: 30 # seconds
+    cooldownPeriod: 10 # seconds
+    triggers:
+      - type: cpu
+        metadata:
+          type: Utilization
+          value: "60"
 
   keyvault:
     name: "cstar-p-rtd-kv"

--- a/helm/rtd/values-prod.yaml
+++ b/helm/rtd/values-prod.yaml
@@ -27,18 +27,10 @@ microservice-chart:
                 operator: In
                 values:
                   - user
-    podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 100
-          podAffinityTerm:
-            labelSelector:
-              matchExpressions:
-                - key: app.kubernetes.io/instance
-                  operator: In
-                  values:
-                    - rtd-ms-sender-auth
-            namespaces: [ "rtd" ]
-            topologyKey: topology.kubernetes.io/zone
+
+  topologySpreadConstraints:
+    create: true
+    useDefaultConfiguration: true
 
   envSecret:
     aks-api-url: cstar-p-weu-prod01-aks-apiserver-url

--- a/helm/rtd/values-uat.yaml
+++ b/helm/rtd/values-uat.yaml
@@ -21,6 +21,10 @@ microservice-chart:
   envSecret:
     aks-api-url: cstar-u-weu-uat01-aks-apiserver-url
 
+  topologySpreadConstraints:
+    create: true
+    useDefaultConfiguration: true
+    
   #  autoscaling:
   #    enable: false
   #    minReplica: 1

--- a/helm/rtd/values-uat.yaml
+++ b/helm/rtd/values-uat.yaml
@@ -25,25 +25,24 @@ microservice-chart:
     create: true
     useDefaultConfiguration: true
     
-  #  autoscaling:
-  #    enable: false
-  #    minReplica: 1
-  #    maxReplica: 2
-  #    pollingInterval: 30 # seconds
-  #    cooldownPeriod: 300 # seconds
-  #    triggers:
-  #      - type: azure-monitor
-  #        metadata:
-  #          tenantId: 7788edaf-0346-4068-9d79-c868aed15b3d
-  #          subscriptionId: ac17914c-79bf-48fa-831e-1359ef74c1d5
-  #          resourceGroupName: dvopla-d-sec-rg
-  #          resourceURI: Microsoft.KeyVault/vaults/dvopla-d-neu-kv
-  #          metricName: ServiceApiHit
-  #          # metricNamespace: Microsoft.KeyVault/vaults
-  #          # metricFilter: namespace eq 'default'
-  #          # metricAggregationInterval: "-1:1:0"
-  #          metricAggregationType: Count
-  #          targetValue: "30"
+  autoscaling:
+    enable: true
+    minReplica: 0
+    maxReplica: 1
+    pollingInterval: 30 # seconds
+    cooldownPeriod: 10 # seconds
+    triggers:
+      - type: cron
+        metadata:
+          # Required
+          timezone: Europe/Rome  # The acceptable values would be a value from the IANA Time Zone Database.
+          start: 0 7 * * *
+          end: 0 21 * * *
+          desiredReplicas: "1"
+      - type: cpu
+        metadata:
+          type: Utilization
+          value: "60"
 
   keyvault:
     name: "cstar-u-rtd-kv"

--- a/helm/rtd/values.yaml
+++ b/helm/rtd/values.yaml
@@ -38,9 +38,10 @@ microservice-chart:
     servicePort: 8080
 
   serviceAccount:
-    create: false
-    annotations: {}
-    name: ""
+    name: "rtd-workload-identity" # Replace with your service account name if using workload identity
+    # If using Azure Workload Identity, also add the azure section:
+    azure:
+      workloadIdentityClientId: "CHANGEME" # Insert your clientId here if needed
 
   podSecurityContext:
     seccompProfile:

--- a/helm/rtd/values.yaml
+++ b/helm/rtd/values.yaml
@@ -47,7 +47,11 @@ microservice-chart:
       type: RuntimeDefault
 
   securityContext:
+    readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - all
     runAsNonRoot: true
     runAsUser: 10000
     runAsGroup: 10000
@@ -56,6 +60,14 @@ microservice-chart:
     MONGODB_CONNECTION_URI: mongo-db-connection-uri
     APPLICATIONINSIGHTS_CONNECTION_STRING: appinsights-connection-string
 
-  envConfigMapExternals:
+  tmpVolumeMount:
+    create: true
+    mounts:
+      - name: tmp
+        mountPath: /tmp
+      - name: logs
+        mountPath: /app/logs
+
+  externalConfigMapValues:
     rtdsenderauth:
       OPENTELEMETRY_LOG_LEVEL: APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- chart upgrated to v8.0.0
- added keda for autoscaling
- migrated values
- added serviceAccount info
- added topologySpreadConstraints to be more resilient with az nodes
- added script deploy.sh to test the deploy
- updated the azdo pipeline to allow the injection of workloadIdentityClientId

#### Motivation and Context

The helm chart must be upgrated to version 8.0.0 that support workload identity and drop the podIdentity that is deprecated by aks

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.